### PR TITLE
Add hide check to write_arg_markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#3711f2",
+    "activityBar.background": "#3711f2",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#3c0d03",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#3711f2",
+    "statusBar.background": "#2a0bc5",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#3711f2",
+    "statusBarItem.remoteBackground": "#2a0bc5",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#2a0bc5",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#2a0bc599",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.color": "#2a0bc5"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ fn build_command_markdown(
         buffer,
         "{} {}\n",
         // "#".repeat(depth + 1),
-        "#",
+        "###",
         command_path.join(" "),
     )?;
 
@@ -197,7 +197,7 @@ fn build_command_markdown(
     //----------------------------------
 
     if command.get_subcommands().next().is_some() {
-        writeln!(buffer, "###### **Subcommands:**\n")?;
+        writeln!(buffer, "#### **Subcommands:**\n")?;
 
         for subcommand in command.get_subcommands() {
             if subcommand.is_hide_set() {
@@ -223,7 +223,7 @@ fn build_command_markdown(
     //----------------------------------
 
     if command.get_positionals().next().is_some() {
-        writeln!(buffer, "###### **Arguments:**\n")?;
+        writeln!(buffer, "#### **Arguments:**\n")?;
 
         for pos_arg in command.get_positionals() {
             write_arg_markdown(buffer, pos_arg)?;
@@ -242,7 +242,7 @@ fn build_command_markdown(
         .collect();
 
     if !non_pos.is_empty() {
-        writeln!(buffer, "###### **Options:**\n")?;
+        writeln!(buffer, "#### **Options:**\n")?;
 
         for arg in non_pos {
             write_arg_markdown(buffer, arg)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,17 +80,24 @@ fn build_table_of_contents_markdown(
         return Ok(());
     }
 
+    let command_name = command
+        .get_bin_name()
+        .or(Some(command.get_name()))
+        .unwrap()
+        .to_owned();
+
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path;
-        command_path.push(command.get_name().to_owned());
+        command_path.push(command_name.clone());
         command_path
     };
 
     writeln!(
         buffer,
-        "* [{}](#{})",
-        command_path.join(" "),
+        "{}* [{}](#{})",
+        "  ".repeat(depth),
+        command_name,
         command_path.join("-"),
     )?;
 
@@ -110,51 +117,6 @@ fn build_table_of_contents_markdown(
     Ok(())
 }
 
-/*
-fn build_table_of_contents_html(
-    buffer: &mut String,
-    // Parent commands of `command`.
-    parent_command_path: Vec<String>,
-    command: &clap::Command,
-    depth: usize,
-) -> std::fmt::Result {
-    // Don't document commands marked with `clap(hide = true)` (which includes
-    // `print-all-help`).
-    if command.is_hide_set() {
-        return Ok(());
-    }
-
-    // Append the name of `command` to `command_path`.
-    let command_path = {
-        let mut command_path = parent_command_path;
-        command_path.push(command.get_name().to_owned());
-        command_path
-    };
-
-    writeln!(
-        buffer,
-        "<li><a href=\"#{}\"><code>{}</code>↴</a></li>",
-        command_path.join("-"),
-        command_path.join(" ")
-    )?;
-
-    //----------------------------------
-    // Recurse to write subcommands
-    //----------------------------------
-
-    for subcommand in command.get_subcommands() {
-        build_table_of_contents_html(
-            buffer,
-            command_path.clone(),
-            subcommand,
-            depth + 1,
-        )?;
-    }
-
-    Ok(())
-}
-*/
-
 fn build_command_markdown(
     buffer: &mut String,
     // Parent commands of `command`.
@@ -171,7 +133,13 @@ fn build_command_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path.clone();
-        command_path.push(command.get_name().to_owned());
+        command_path.push(
+            command
+                .get_bin_name()
+                .or(Some(command.get_name()))
+                .unwrap()
+                .to_owned(),
+        );
         command_path
     };
 
@@ -191,9 +159,9 @@ fn build_command_markdown(
 
     writeln!(
         buffer,
-        "{} `{}`\n",
+        "{} {}\n",
         // "#".repeat(depth + 1),
-        "##",
+        "#",
         command_path.join(" "),
     )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,9 +384,9 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
     }
 
     if let Some(help) = arg.get_help() {
-        writeln!(buffer, " — {help}")?;
+        writeln!(buffer, " — {help}\n")?;
     } else {
-        writeln!(buffer)?;
+        writeln!(buffer, "\n")?;
     }
 
     //--------------------
@@ -403,10 +403,10 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
 
         if arg.get_default_values().len() > 1 {
             // Plural
-            writeln!(buffer, "\n  Default values: {default_values}")?;
+            writeln!(buffer, "\n  Default values: {default_values}\n")?;
         } else {
             // Singular
-            writeln!(buffer, "\n  Default value: {default_values}")?;
+            writeln!(buffer, "\n  Default value: {default_values}\n")?;
         }
     }
 
@@ -461,6 +461,8 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
             writeln!(buffer, "\n  Possible values: {text}\n")?;
         }
     }
+
+    writeln!(buffer, "  &nbsp;\n")?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,29 +51,8 @@ pub fn print_help_markdown<C: clap::CommandFactory>() {
 
 fn write_help_markdown(buffer: &mut String, command: &clap::Command) {
     //----------------------------------
-    // Write the document title
-    //----------------------------------
-
-    let title_name = match command.get_display_name() {
-        Some(display_name) => display_name.to_owned(),
-        None => format!("`{}`", command.get_name()),
-    };
-
-    writeln!(buffer, "# Command-Line Help for {title_name}\n").unwrap();
-
-    writeln!(
-        buffer,
-        "This document contains the help content for the `{}` command-line program.\n",
-        command.get_name()
-    ).unwrap();
-
-    //----------------------------------
     // Write the table of contents
     //----------------------------------
-
-    // writeln!(buffer, r#"<div style="background: light-gray"><ul>"#).unwrap();
-    // build_table_of_contents_html(buffer, Vec::new(), command, 0).unwrap();
-    // writeln!(buffer, "</ul></div>").unwrap();
 
     writeln!(buffer, "**Command Overview:**\n").unwrap();
 
@@ -86,18 +65,6 @@ fn write_help_markdown(buffer: &mut String, command: &clap::Command) {
     //----------------------------------------
 
     build_command_markdown(buffer, Vec::new(), command, 0).unwrap();
-
-    //-----------------
-    // Write the footer
-    //-----------------
-
-    write!(buffer, r#"<hr/>
-
-<small><i>
-    This document was generated automatically by
-    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
-</i></small>
-"#).unwrap();
 }
 
 fn build_table_of_contents_markdown(
@@ -116,13 +83,13 @@ fn build_table_of_contents_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path;
-        command_path.push(command.get_name().to_owned());
+        command_path.push(command.get_bin_name().unwrap().to_owned());
         command_path
     };
 
     writeln!(
         buffer,
-        "* [`{}`↴](#{})",
+        "* [{}](#{})",
         command_path.join(" "),
         command_path.join("-"),
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ mod test_readme {
     #![doc = include_str!("../README.md")]
 }
 
-
 use std::fmt::{self, Write};
 
 use clap::builder::PossibleValue;
@@ -338,6 +337,11 @@ fn build_command_markdown(
 }
 
 fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
+    // Don't document commands marked with `clap(hide = true)`.
+    if arg.is_hide_set() {
+        return Ok(());
+    }
+
     // Markdown list item
     write!(buffer, "* ")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ fn build_table_of_contents_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path;
-        command_path.push(command.get_bin_name().unwrap().to_owned());
+        command_path.push(command.get_name().to_owned());
         command_path
     };
 


### PR DESCRIPTION
Hidden arguments are now correctly filtered out from the markdown documentation.