### PR TITLE
feat: add support for custom before/after help

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,9 +237,11 @@ fn build_command_markdown(
         writeln!(buffer, "{}\n", about)?;
     }
 
-    // TODO(feature): Support printing custom before and after help texts.
-    assert!(command.get_before_help().is_none());
-    assert!(command.get_after_help().is_none());
+    if let Some(help) = command.get_before_long_help() {
+        writeln!(buffer, "{}\n", help)?;
+    } else if let Some(help) = command.get_before_help() {
+        writeln!(buffer, "{}\n", help)?;
+    }
 
     writeln!(
         buffer,
@@ -257,6 +259,12 @@ fn build_command_markdown(
             .to_string()
             .replace("Usage: ", "")
     )?;
+
+    if let Some(help) = command.get_after_long_help() {
+        writeln!(buffer, "{}\n", help)?;
+    } else if let Some(help) = command.get_after_help() {
+        writeln!(buffer, "{}\n", help)?;
+    }
 
     //----------------------------------
     // Subcommands


### PR DESCRIPTION
To me, it made the most sense to simply put these before and after the usage.