### PR TITLE
Do not show extraneous true/false possible values, skip hidden arguments 

### DIFF
--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -47,9 +47,6 @@ does testing things
 
 * `-l`, `--list` — lists test values
 
-  Possible values: `true`, `false`
-
-
 
 
 <hr/>

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -47,6 +47,9 @@ does testing things
 
 * `-l`, `--list` — lists test values
 
+  Possible values: `true`, `false`
+
+
 
 
 <hr/>

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -6,6 +6,7 @@ This document contains the help content for the `complex-app` command-line progr
 
 * [`complex-app`↴](#complex-app)
 * [`complex-app test`↴](#complex-app-test)
+* [`complex-app only-hidden-options`↴](#complex-app-only-hidden-options)
 
 ## `complex-app`
 
@@ -16,6 +17,7 @@ An example command-line tool
 ###### **Subcommands:**
 
 * `test` — does testing things
+* `only-hidden-options` — Demo that `Options` is not printed if all options are hidden
 
 ###### **Arguments:**
 
@@ -46,6 +48,14 @@ does testing things
 ###### **Options:**
 
 * `-l`, `--list` — lists test values
+
+
+
+## `complex-app only-hidden-options`
+
+Demo that `Options` is not printed if all options are hidden
+
+**Usage:** `complex-app only-hidden-options`
 
 
 

--- a/docs/examples/complex_app.rs
+++ b/docs/examples/complex_app.rs
@@ -20,6 +20,9 @@ pub struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     debug: u8,
 
+    #[arg(short, long, hide = true)]
+    secret_arg: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -31,6 +34,11 @@ enum Commands {
         /// lists test values
         #[arg(short, long)]
         list: bool,
+    },
+    /// Demo that `Options` is not printed if all options are hidden
+    OnlyHiddenOptions {
+        #[arg(short, long, hide = true)]
+        secret: bool,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ fn build_command_markdown(
 
     let non_pos: Vec<_> = command
         .get_arguments()
-        .filter(|arg| !arg.is_positional())
+        .filter(|arg| !arg.is_positional() && !arg.is_hide_set())
         .collect();
 
     if !non_pos.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,11 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
         .filter(|pv| !pv.is_hide_set())
         .collect();
 
-    if !possible_values.is_empty() {
+    // Print possible values for options that take a value, but not for flags
+    // that can only be either present or absent and do not take a value.
+    if !possible_values.is_empty()
+        && !matches!(arg.get_action(), clap::ArgAction::SetTrue)
+    {
         let any_have_help: bool =
             possible_values.iter().any(|pv| pv.get_help().is_some());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,9 @@ fn build_command_markdown(
 }
 
 fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
+    // Markdown list item
+    write!(buffer, "* ")?;
+
     let value_name: String = match arg.get_value_names() {
         // TODO: What if multiple names are provided?
         Some([name, ..]) => name.as_str().to_owned(),
@@ -347,8 +350,6 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
         None => arg.get_id().to_string().to_ascii_uppercase(),
     };
 
-    // Markdown list item
-    write!(buffer, "* ")?;
     match (arg.get_short(), arg.get_long()) {
         (Some(short), Some(long)) => {
             if arg.get_action().takes_values() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,9 +338,6 @@ fn build_command_markdown(
 }
 
 fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
-    // Markdown list item
-    write!(buffer, "* ")?;
-
     let value_name: String = match arg.get_value_names() {
         // TODO: What if multiple names are provided?
         Some([name, ..]) => name.as_str().to_owned(),
@@ -350,6 +347,8 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
         None => arg.get_id().to_string().to_ascii_uppercase(),
     };
 
+    // Markdown list item
+    write!(buffer, "* ")?;
     match (arg.get_short(), arg.get_long()) {
         (Some(short), Some(long)) => {
             if arg.get_action().takes_values() {


### PR DESCRIPTION
Fixes #18, fixes #19. See commit descriptions for more details.

This PR competes with #15, but I believe the method I use here is better.

This duplicates https://github.com/janstarke/clap-markdown-dfir/pull/1, but is rebased onto this repo's main branch.