### PR TITLE
feature: Print long help text for options

### DIFF
--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -49,6 +49,9 @@ does testing things
 
 * `-l`, `--list` — lists test values
 
+  Possible values: `true`, `false`
+
+
 
 
 ## `complex-app only-hidden-options`

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -23,6 +23,8 @@ An example command-line tool
 
 * `<NAME>` — Optional name to operate on
 
+   Longer description
+
 ###### **Options:**
 
 * `-c`, `--config <FILE>` — Sets a custom config file
@@ -36,6 +38,8 @@ An example command-line tool
   - `remote`
 
 * `-d`, `--debug` — Turn debugging information on
+
+   Repeat this option to see more and more debug information.
 
 
 

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -53,9 +53,6 @@ does testing things
 
 * `-l`, `--list` — lists test values
 
-  Possible values: `true`, `false`
-
-
 
 
 ## `complex-app only-hidden-options`

--- a/docs/examples/complex_app.rs
+++ b/docs/examples/complex_app.rs
@@ -7,6 +7,8 @@ use clap::{Parser, Subcommand};
 #[command(name = "complex-app")]
 pub struct Cli {
     /// Optional name to operate on
+    ///
+    /// Longer description
     name: Option<String>,
 
     /// Sets a custom config file
@@ -17,6 +19,8 @@ pub struct Cli {
     target: Target,
 
     /// Turn debugging information on
+    ///
+    /// Repeat this option to see more and more debug information.
     #[arg(short, long, action = clap::ArgAction::Count)]
     debug: u8,
 


### PR DESCRIPTION
This fixes #20.

I separated this from #22 since there is a bit more logic here. The first commit is shared with #22, since test changes are confusing without that commit. I will rebase one of the PRs if you merge the other (unless you do it).

This duplicates https://github.com/janstarke/clap-markdown-dfir/pull/2, but is rebased onto this repo's main branch.