### PR TITLE
[PR Integration] Use `display_name` wherever possible + table of contents option

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Contents of the command title header.
   - Whether to show the footer explaining the documentation was generated with
     `clap-markdown`.
+  - Whether to show the command overview table of contents.
+
+### Changed
+
+* `clap-markdown` will now respect the `Command.display_name` property, if set,
+  and use it in the rendered Markdown when showing the name and usage of the
+  command.
+  ([#27],
+  co-authored-by [@keturiosakys](https://github.com/keturiosakys)
+  and [@hatchan](https://github.com/hatchan))
 
 
 
@@ -115,6 +125,9 @@ Initial release of `clap-markdown`.
 
 <!-- v0.1.3 -->
 [#11]: https://github.com/ConnorGray/clap-markdown/pull/11
+
+<!-- Unreleased -->
+[#27]: https://github.com/ConnorGray/clap-markdown/pull/27
 
 [unreleased]: https://github.com/ConnorGray/clap-markdown/compare/v0.1.3...HEAD
 

--- a/docs/examples/complex-app-custom.md
+++ b/docs/examples/complex-app-custom.md
@@ -2,12 +2,6 @@
 
 This document contains the help content for the `complex-app` command-line program.
 
-**Command Overview:**
-
-* [`complex-app`↴](#complex-app)
-* [`complex-app test`↴](#complex-app-test)
-* [`complex-app only-hidden-options`↴](#complex-app-only-hidden-options)
-
 ## `complex-app`
 
 An example command-line tool

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -1,4 +1,4 @@
-# Command-Line Help for complex-app
+# Command-Line Help for `complex-app`
 
 This document contains the help content for the `complex-app` command-line program.
 

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -1,4 +1,4 @@
-# Command-Line Help for `complex-app`
+# Command-Line Help for complex-app
 
 This document contains the help content for the `complex-app` command-line program.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ fn write_help_markdown(
     writeln!(
         buffer,
         "This document contains the help content for the `{}` command-line program.\n",
-        command.get_name()
+        command.get_display_name().unwrap_or_else(|| command.get_name())
     ).unwrap();
 
     //----------------------------------
@@ -189,7 +189,12 @@ fn build_table_of_contents_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path;
-        command_path.push(command.get_name().to_owned());
+        command_path.push(
+            command
+                .get_display_name()
+                .unwrap_or_else(|| command.get_name())
+                .to_owned(),
+        );
         command_path
     };
 
@@ -277,7 +282,12 @@ fn build_command_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path.clone();
-        command_path.push(command.get_name().to_owned());
+        command_path.push(
+            command
+                .get_display_name()
+                .unwrap_or_else(|| command.get_name())
+                .to_owned(),
+        );
         command_path
     };
 
@@ -353,7 +363,9 @@ fn build_command_markdown(
             writeln!(
                 buffer,
                 "* `{}` — {}",
-                subcommand.get_name(),
+                subcommand
+                    .get_display_name()
+                    .unwrap_or_else(|| subcommand.get_name()),
                 match subcommand.get_about() {
                     Some(about) => about.to_string(),
                     None => String::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,9 +560,14 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
     Ok(())
 }
 
-// This is a utility function to get the canonical name of a command. It's logic is
-// to get the display name if it exists, otherwise get the bin name if it exists, otherwise
-// get the package name.
+/// Utility function to get the canonical name of a command.
+///
+/// It's logic is to get the display name if it exists, otherwise get the bin
+/// name if it exists, otherwise get the package name.
+///
+/// Note that the default `Command.name` field of a clap command is typically
+/// meant for programmatic usage as well as for display (if no `display_name`
+/// override is set).
 fn get_canonical_name(command: &clap::Command) -> String {
     command
         .get_display_name()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,13 +564,11 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
 // to get the display name if it exists, otherwise get the bin name if it exists, otherwise
 // get the package name.
 fn get_canonical_name(command: &clap::Command) -> String {
-    return match command.get_display_name() {
-        Some(bin_name) => bin_name.to_owned(),
-        None => command
-            .get_bin_name()
-            .unwrap_or_else(|| command.get_name())
-            .to_owned(),
-    };
+    command
+        .get_display_name()
+        .or_else(|| command.get_bin_name())
+        .map(|name| name.to_owned())
+        .unwrap_or_else(|| command.get_name().to_owned())
 }
 
 /// Indents non-empty lines. The output always ends with a newline.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,12 +365,12 @@ fn build_command_markdown(
 
             let title_name = get_canonical_name(subcommand);
 
-            writeln!(buffer, "* `{}` — {}", title_name, match subcommand
-                .get_about()
-            {
+            let about = match subcommand.get_about() {
                 Some(about) => about.to_string(),
                 None => String::new(),
-            })?;
+            };
+
+            writeln!(buffer, "* `{title_name}` — {about}",)?;
         }
 
         write!(buffer, "\n")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,19 +182,6 @@ fn write_help_markdown(
     }
 }
 
-// This is a utility function to get the canonical name of a command. It's logic is
-// to get the display name if it exists, otherwise get the bin name if it exists, otherwise
-// get the package name.
-fn get_canonical_name(command: &clap::Command) -> String {
-    return match command.get_display_name() {
-        Some(bin_name) => bin_name.to_owned(),
-        None => command
-            .get_bin_name()
-            .unwrap_or_else(|| command.get_name())
-            .to_owned(),
-    };
-}
-
 fn build_table_of_contents_markdown(
     buffer: &mut String,
     // Parent commands of `command`.
@@ -571,6 +558,19 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
     }
 
     Ok(())
+}
+
+// This is a utility function to get the canonical name of a command. It's logic is
+// to get the display name if it exists, otherwise get the bin name if it exists, otherwise
+// get the package name.
+fn get_canonical_name(command: &clap::Command) -> String {
+    return match command.get_display_name() {
+        Some(bin_name) => bin_name.to_owned(),
+        None => command
+            .get_bin_name()
+            .unwrap_or_else(|| command.get_name())
+            .to_owned(),
+    };
 }
 
 /// Indents non-empty lines. The output always ends with a newline.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ fn write_help_markdown(
 
     let title = match options.title {
         Some(ref title) => title.to_owned(),
-        None => format!("Command-Line Help for {title_name}"),
+        None => format!("Command-Line Help for `{title_name}`"),
     };
     writeln!(buffer, "# {title}\n",).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,13 +131,7 @@ fn write_help_markdown(
     // Write the document title
     //----------------------------------
 
-    let title_name = match command.get_display_name() {
-        Some(bin_name) => bin_name.to_owned(),
-        None => command
-            .get_bin_name()
-            .unwrap_or_else(|| command.get_name())
-            .to_owned(),
-    };
+    let title_name = get_canonical_name(command);
 
     let title = match options.title {
         Some(ref title) => title.to_owned(),
@@ -188,6 +182,19 @@ fn write_help_markdown(
     }
 }
 
+// This is a utility function to get the canonical name of a command. It's logic is
+// to get the display name if it exists, otherwise get the bin name if it exists, otherwise
+// get the package name.
+fn get_canonical_name(command: &clap::Command) -> String {
+    return match command.get_display_name() {
+        Some(bin_name) => bin_name.to_owned(),
+        None => command
+            .get_bin_name()
+            .unwrap_or_else(|| command.get_name())
+            .to_owned(),
+    };
+}
+
 fn build_table_of_contents_markdown(
     buffer: &mut String,
     // Parent commands of `command`.
@@ -201,12 +208,7 @@ fn build_table_of_contents_markdown(
         return Ok(());
     }
 
-    let title_name = command
-        .get_display_name()
-        .unwrap_or_else(|| {
-            command.get_bin_name().unwrap_or_else(|| command.get_name())
-        })
-        .to_owned();
+    let title_name = get_canonical_name(command);
 
     // Append the name of `command` to `command_path`.
     let command_path = {
@@ -296,12 +298,7 @@ fn build_command_markdown(
         return Ok(());
     }
 
-    let title_name = command
-        .get_display_name()
-        .unwrap_or_else(|| {
-            command.get_bin_name().unwrap_or_else(|| command.get_name())
-        })
-        .to_owned();
+    let title_name = get_canonical_name(command);
 
     // Append the name of `command` to `command_path`.
     let command_path = {
@@ -379,12 +376,7 @@ fn build_command_markdown(
                 continue;
             }
 
-            let title_name = subcommand
-                .get_display_name()
-                .unwrap_or_else(|| {
-                    command.get_bin_name().unwrap_or_else(|| command.get_name())
-                })
-                .to_owned();
+            let title_name = get_canonical_name(subcommand);
 
             writeln!(buffer, "* `{}` — {}", title_name, match subcommand
                 .get_about()

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -19,6 +19,7 @@ fn test_example_complex_app() {
             &MarkdownOptions::new()
                 .title(format!("Some Custom Title for Complex App"))
                 .show_footer(false)
+                .show_table_of_contents(false)
         ),
         include_str!("../docs/examples/complex-app-custom.md"),
         "Mismatch testing CUSTOM Markdown output"

--- a/tests/test_markdown.rs
+++ b/tests/test_markdown.rs
@@ -54,7 +54,7 @@ Options:
             &MarkdownOptions::new().show_footer(false)
         ),
         "\
-# Command-Line Help for my-program-display-name
+# Command-Line Help for `my-program-display-name`
 
 This document contains the help content for the `my-program-display-name` command-line program.
 
@@ -129,7 +129,7 @@ Options:
             &MarkdownOptions::new().show_footer(false)
         ),
         "\
-# Command-Line Help for my-program-display-name
+# Command-Line Help for `my-program-display-name`
 
 This document contains the help content for the `my-program-display-name` command-line program.
 

--- a/tests/test_markdown.rs
+++ b/tests/test_markdown.rs
@@ -56,13 +56,13 @@ Options:
         "\
 # Command-Line Help for my-program-display-name
 
-This document contains the help content for the `my-program-name` command-line program.
+This document contains the help content for the `my-program-display-name` command-line program.
 
 **Command Overview:**
 
-* [`my-program-name`↴](#my-program-name)
+* [`my-program-display-name`↴](#my-program-display-name)
 
-## `my-program-name`
+## `my-program-display-name`
 
 This program does things.
 
@@ -131,13 +131,13 @@ Options:
         "\
 # Command-Line Help for my-program-display-name
 
-This document contains the help content for the `my-program-name` command-line program.
+This document contains the help content for the `my-program-display-name` command-line program.
 
 **Command Overview:**
 
-* [`my-program-name`↴](#my-program-name)
+* [`my-program-display-name`↴](#my-program-display-name)
 
-## `my-program-name`
+## `my-program-display-name`
 
 This program does things.
 


### PR DESCRIPTION
This integrates the work originally done in #14 by @keturiosakys.

I had to rebase and fix some merge conflicts, but I've tried to ensure the appropriate git authorship credit is preserved in the history (@keturiosakys as the main author, and a Co-authored-by me in the commit I had to alter significantly during the rebase).