### PR TITLE
feat: add support for argument aliases in markdown output

### DIFF
--- a/docs/examples/complex-app-custom.md
+++ b/docs/examples/complex-app-custom.md
@@ -10,7 +10,7 @@ An example command-line tool
 
 ###### **Subcommands:**
 
-* `test` — does testing things
+* `test` [alias: `tester`] — does testing things
 * `only-hidden-options` — Demo that `Options` is not printed if all options are hidden
 
 ###### **Arguments:**
@@ -21,7 +21,7 @@ An example command-line tool
 
 ###### **Options:**
 
-* `-c`, `--config <FILE>` — Sets a custom config file
+* `-c`, `--config <FILE>` [alias: `configuration`] — Sets a custom config file
 * `--target <TARGET>`
 
   Default value: `local`
@@ -31,13 +31,14 @@ An example command-line tool
     Do the operation locally
   - `remote`
 
+* `--very-very-verbose` [aliases: `vv`, `vvv`]
 * `-d`, `--debug` — Turn debugging information on
 
    Repeat this option to see more and more debug information.
 
 
 
-## `complex-app test`
+## `complex-app test` [alias: `tester`]
 
 does testing things
 

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -16,7 +16,7 @@ An example command-line tool
 
 ###### **Subcommands:**
 
-* `test` — does testing things
+* `test` [alias: `tester`] — does testing things
 * `only-hidden-options` — Demo that `Options` is not printed if all options are hidden
 
 ###### **Arguments:**
@@ -27,7 +27,7 @@ An example command-line tool
 
 ###### **Options:**
 
-* `-c`, `--config <FILE>` — Sets a custom config file
+* `-c`, `--config <FILE>` [alias: `configuration`] — Sets a custom config file
 * `--target <TARGET>`
 
   Default value: `local`
@@ -37,13 +37,14 @@ An example command-line tool
     Do the operation locally
   - `remote`
 
+* `--very-very-verbose` [aliases: `vv`, `vvv`]
 * `-d`, `--debug` — Turn debugging information on
 
    Repeat this option to see more and more debug information.
 
 
 
-## `complex-app test`
+## `complex-app test` [alias: `tester`]
 
 does testing things
 

--- a/docs/examples/complex_app.rs
+++ b/docs/examples/complex_app.rs
@@ -12,11 +12,14 @@ pub struct Cli {
     name: Option<String>,
 
     /// Sets a custom config file
-    #[arg(short, long, value_name = "FILE")]
+    #[arg(short, long, value_name = "FILE", visible_alias = "configuration")]
     config: Option<PathBuf>,
 
     #[arg(long, default_value = "local")]
     target: Target,
+
+    #[arg(long, visible_alias = "vv", visible_alias = "vvv")]
+    very_very_verbose: bool,
 
     /// Turn debugging information on
     ///
@@ -34,6 +37,7 @@ pub struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// does testing things
+    #[command(visible_alias = "tester")]
     Test {
         /// lists test values
         #[arg(short, long)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,14 +307,12 @@ fn build_command_markdown(
         )
     }
     */
+    let aliases = command.get_visible_aliases().collect::<Vec<&str>>();
+    let aliases = get_alias_str(&aliases)
+        .map(|s| format!(" {s}"))
+        .unwrap_or_default();
 
-    writeln!(
-        buffer,
-        "{} `{}`\n",
-        // "#".repeat(depth + 1),
-        "##",
-        command_path.join(" "),
-    )?;
+    writeln!(buffer, "## `{}`{aliases}\n", command_path.join(" "),)?;
 
     if let Some(long_about) = command.get_long_about() {
         writeln!(buffer, "{}\n", long_about)?;
@@ -364,13 +362,17 @@ fn build_command_markdown(
             }
 
             let title_name = get_canonical_name(subcommand);
+            let aliases = subcommand.get_visible_aliases().collect::<Vec<&str>>();
+            let aliases = get_alias_str(&aliases)
+                .map(|s| format!(" {s}"))
+                .unwrap_or_default();
 
             let about = match subcommand.get_about() {
                 Some(about) => about.to_string(),
                 None => String::new(),
             };
 
-            writeln!(buffer, "* `{title_name}` — {about}",)?;
+            writeln!(buffer, "* `{title_name}`{aliases} — {about}",)?;
         }
 
         write!(buffer, "\n")?;
@@ -469,6 +471,12 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
 
             write!(buffer, "`<{value_name}>`",)?;
         },
+    }
+
+    if let Some(aliases) = arg.get_visible_aliases().as_deref() {
+        if let Some(aliases) = get_alias_str(aliases) {
+            write!(buffer, " {aliases}")?;
+        }
     }
 
     if let Some(help) = arg.get_long_help() {
@@ -595,6 +603,35 @@ fn indent(s: &str, first: &str, rest: &str) -> String {
         result.push('\n');
     }
     result
+}
+
+fn wrap_with(s: &str, wrapper: &str) -> String {
+    format!("{wrapper}{s}{wrapper}")
+}
+
+fn wrap_with_backticks(s: &str) -> String {
+    wrap_with(s, "`")
+}
+
+fn get_alias_str(aliases: &[&str]) -> Option<String> {
+    if aliases.is_empty() {
+        return None;
+    }
+
+    let prefix = if aliases.len() == 1 {
+        "alias"
+    } else {
+        "aliases"
+    };
+
+    Some(format!(
+        "[{prefix}: {}]",
+        aliases
+            .iter()
+            .map(|s| wrap_with_backticks(s))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
 }
 
 #[cfg(test)]

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -17,7 +17,7 @@ fn test_example_complex_app() {
     assert_eq!(
         clap_markdown::help_markdown_custom::<complex_app::Cli>(
             &MarkdownOptions::new()
-                .title(format!("Some Custom Title for Complex App"))
+                .title("Some Custom Title for Complex App".to_string())
                 .show_footer(false)
                 .show_table_of_contents(false)
         ),


### PR DESCRIPTION
Currently it adds the alias after the current options before the help doc. Open to other suggestions.