### PR TITLE
polish: Add `show_aliases` option + change where aliases appear

### DIFF
--- a/docs/examples/complex-app-custom.md
+++ b/docs/examples/complex-app-custom.md
@@ -10,7 +10,7 @@ An example command-line tool
 
 ###### **Subcommands:**
 
-* `test` [alias: `tester`] — does testing things
+* `test` — does testing things
 * `only-hidden-options` — Demo that `Options` is not printed if all options are hidden
 
 ###### **Arguments:**
@@ -38,7 +38,7 @@ An example command-line tool
 
 
 
-## `complex-app test` [alias: `tester`]
+## `complex-app test`
 
 does testing things
 

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -16,7 +16,7 @@ An example command-line tool
 
 ###### **Subcommands:**
 
-* `test` [alias: `tester`] — does testing things
+* `test` — does testing things
 * `only-hidden-options` — Demo that `Options` is not printed if all options are hidden
 
 ###### **Arguments:**
@@ -44,11 +44,13 @@ An example command-line tool
 
 
 
-## `complex-app test` [alias: `tester`]
+## `complex-app test`
 
 does testing things
 
 **Usage:** `complex-app test [OPTIONS]`
+
+**Command Alias:** `tester`
 
 ###### **Options:**
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,6 @@
+pub fn pluralize<T>(len: usize, singular: T, plural: T) -> T {
+    match len {
+        1 => singular,
+        _ => plural,
+    }
+}

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -20,6 +20,7 @@ fn test_example_complex_app() {
                 .title("Some Custom Title for Complex App".to_string())
                 .show_footer(false)
                 .show_table_of_contents(false)
+                .show_aliases(false)
         ),
         include_str!("../docs/examples/complex-app-custom.md"),
         "Mismatch testing CUSTOM Markdown output"


### PR DESCRIPTION
This is a follow-up to the aliases feature generously started in #36 by @willemneal 🙂

Here I add a new option to control whether aliases are emitted, and also make small changes to the formatting:

1. Print command aliases only in their dedicated section, not in the subcommands listing of the parent command.
2. Move the command aliases out of the command header (simplifying the generated anchor link text) and into a bolded section underneath. 