### PR TITLE
feat: Add version information to generated Markdown

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,16 @@ fn write_help_markdown(
     //----------------------------------
 
     if let Some(version) = command.get_version() {
-        writeln!(buffer, "**Version:** `{}`\n", version).unwrap();
+        let version_str = version.to_string();
+
+        // Check if version contains multiple lines
+        if version_str.contains('\n') {
+            // Multi-line version: use a code block
+            writeln!(buffer, "**Version:**\n\n```\n{}\n```\n", version_str.trim()).unwrap();
+        } else {
+            // Single-line version: use inline code
+            writeln!(buffer, "**Version:** `{}`\n", version_str).unwrap();
+        }
     }
 
     //----------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,14 @@ fn write_help_markdown(
     ).unwrap();
 
     //----------------------------------
+    // Write the version if available
+    //----------------------------------
+
+    if let Some(version) = command.get_version() {
+        writeln!(buffer, "**Version:** `{}`\n", version).unwrap();
+    }
+
+    //----------------------------------
     // Write the table of contents
     //----------------------------------
 

--- a/tests/test_markdown.rs
+++ b/tests/test_markdown.rs
@@ -158,3 +158,54 @@ This program does things.
 "
     );
 }
+
+/// Test behavior for an app with a multi-line version string
+#[test]
+fn test_version_behavior_for_multi_line_version_string() {
+    let multi_line_version = "my-cli 1.2.3 (abc123def)\nmy-lib 2.0.0 (789xyz456)\ndependency 3.1.0 (fedcba987)";
+
+    let mut app = Command::new("my-cli")
+        .version(multi_line_version)
+        .about("A CLI tool with multiple component versions")
+        .arg(Arg::new("input").short('i'));
+    let () = app.build();
+
+    assert_eq!(
+        help_markdown_command_custom(
+            &app,
+            &MarkdownOptions::new().show_footer(false)
+        ),
+        "\
+# Command-Line Help for `my-cli`
+
+This document contains the help content for the `my-cli` command-line program.
+
+**Version:**
+
+```
+my-cli 1.2.3 (abc123def)
+my-lib 2.0.0 (789xyz456)
+dependency 3.1.0 (fedcba987)
+```
+
+**Command Overview:**
+
+* [`my-cli`↴](#my-cli)
+
+## `my-cli`
+
+A CLI tool with multiple component versions
+
+**Usage:** `my-cli [OPTIONS]`
+
+###### **Options:**
+
+* `-i <INPUT>`
+* `-h`, `--help` — Print help
+* `-V`, `--version` — Print version
+
+
+
+"
+    );
+}

--- a/tests/test_markdown.rs
+++ b/tests/test_markdown.rs
@@ -58,6 +58,8 @@ Options:
 
 This document contains the help content for the `my-program-display-name` command-line program.
 
+**Version:** `1.2.3`
+
 **Command Overview:**
 
 * [`my-program-display-name`↴](#my-program-display-name)
@@ -132,6 +134,8 @@ Options:
 # Command-Line Help for `my-program-display-name`
 
 This document contains the help content for the `my-program-display-name` command-line program.
+
+**Version:** `1.2.3`
 
 **Command Overview:**
 


### PR DESCRIPTION
### Summary

Adds package version information to the generated markdown documentation. The version now appears near the top of the document, right after the introductory text and before the command overview/table of contents.

### Changes

- Modified markdown generation to include version information when available
- Version is displayed as: `**Version:** `1.2.3``
- Version display is conditional - only shown if the clap `Command` has a version set
- Updated all tests to reflect the new output format

### Example Output

```markdown
# Command-Line Help for `my-app`

This document contains the help content for the `my-app` command-line program.

**Version:** `1.2.3`

**Command Overview:**
(...)
```

### Motivation

Having the version visible in the generated documentation helps users quickly identify which version of the tool the documentation corresponds to. Additionally, this aids AI agents that scrape documentation by providing clear version context.